### PR TITLE
made showNavigationLinks with default true and showDefinition with defaul

### DIFF
--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ResultTraverser.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ResultTraverser.java
@@ -20,7 +20,6 @@ import java.util.List;
  */
 public class ResultTraverser
 {
-   public static final boolean SHOW_NAVIGATION_LINKS = true;
    private FieldPopulatorRegistry _fieldPopulatorRegistry = new DefaultFieldPopulatorRegistry(
          new ArrayList<FieldPopulator<?>>() );
    private URICreator _uriCreator = new URICreator();
@@ -28,7 +27,7 @@ public class ResultTraverser
    private ClassFinderStrategy _classFinderStrategy = new DefaultClassFinderStrategy();
 
    private boolean _showDefinition = false;
-   private boolean _showHref = true;
+   private boolean _showNavigationLinks = true;
 
    public void traverse(Object instance, Selector fieldSelector, HierarchicalModel model,
          String hrefSuffix)
@@ -44,7 +43,7 @@ public class ResultTraverser
       @SuppressWarnings("unchecked")
 	  FieldPopulator<T> populator = (FieldPopulator<T>) _fieldPopulatorRegistry.getFieldPopulator( instanceType );
 
-      if (_showHref)
+      if (_showNavigationLinks)
       {
          addHref( instance, model, instanceType, hrefSuffix, populator );
       }
@@ -213,7 +212,7 @@ public class ResultTraverser
       }
 
       // Extract this into a new method
-      if (SHOW_NAVIGATION_LINKS && unshownProperties.size() > 0
+      if (_showNavigationLinks && unshownProperties.size() > 0
             && fieldSelector instanceof CoreSelector)
       {
          HierarchicalModel navigationLinks = model.createChild( "navigationLinks",
@@ -374,9 +373,9 @@ public class ResultTraverser
    {
       _showDefinition = showDefinition;
    }
-
-   public void setShowHref(boolean showHref)
+   
+   public void setShowNavigationLinks(boolean showNavigationLinks) 
    {
-      _showHref = showHref;
+	   this._showNavigationLinks = showNavigationLinks;
    }
 }

--- a/yoga-demos/yoga-demo-shared/src/main/resources/applicationContext.xml
+++ b/yoga-demos/yoga-demo-shared/src/main/resources/applicationContext.xml
@@ -45,7 +45,9 @@
 
 	<bean id="resultTraverser" class="org.skyscreamer.yoga.mapper.ResultTraverser"
 		p:fieldPopulatorRegistry-ref="fieldPopulatorRegistry"
-		p:classFinderStrategy-ref="hibernateClassFinder" />
+		p:classFinderStrategy-ref="hibernateClassFinder" 
+		p:showNavigationLinks="true" 
+		p:showDefinition="false" />
 
 	<bean id="hibernateClassFinder"
 		class="org.skyscreamer.yoga.demo.mapper.HibernateClassFinderStrategy" />


### PR DESCRIPTION
As per our discussion, I remember wanting to remove both _showDefinition and _showHref flags. Looks like _showDefinition is not part of navigation links, so I left it alone for now. If we do not need that functionality, I can clean it up. 

Looks like ResultTraverser is being integration tested via the demo code, may be adding unit test for this class will help test these conditions independently.  
