### PR TITLE
Object throttle

### DIFF
--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/AbstractHierarchicalModel.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/AbstractHierarchicalModel.java
@@ -6,7 +6,7 @@ import java.beans.PropertyDescriptor;
 public abstract class AbstractHierarchicalModel implements HierarchicalModel
 {
    @Override
-   public HierarchicalModel createChild(PropertyDescriptor property, Object result)
+   public HierarchicalModel createChild(PropertyDescriptor property)
    {
       MapHierarchicalModel child = new MapHierarchicalModel();
       addSimple(property, child.getObjectTree());
@@ -14,7 +14,7 @@ public abstract class AbstractHierarchicalModel implements HierarchicalModel
    }
 
    @Override
-   public HierarchicalModel createChild(String property, Object value)
+   public HierarchicalModel createChild(String property)
    {
       MapHierarchicalModel child = new MapHierarchicalModel();
       addSimple(property, child.getObjectTree());
@@ -22,7 +22,7 @@ public abstract class AbstractHierarchicalModel implements HierarchicalModel
    }
 
    @Override
-   public HierarchicalModel createList(PropertyDescriptor property, Object result)
+   public HierarchicalModel createList(PropertyDescriptor property)
    {
       ListHierarchicalModel child = new ListHierarchicalModel();
       addSimple(property, child.getList());
@@ -30,7 +30,7 @@ public abstract class AbstractHierarchicalModel implements HierarchicalModel
    }
    
    @Override
-   public HierarchicalModel createList(String property, Object value)
+   public HierarchicalModel createList(String property)
    {
       ListHierarchicalModel child = new ListHierarchicalModel();
       addSimple(property, child.getList());

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModel.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModel.java
@@ -7,13 +7,11 @@ public interface HierarchicalModel {
 
     void addSimple(String name, Object result);
 
-    // TODO: Do we really need the value argument for createChild and createList?
-    // Only place I see it used is XhtmlHeirarchyModel, and doesn't seem necessary there.  Seems YAGNI.
-    HierarchicalModel createChild(PropertyDescriptor property, Object value);
+    HierarchicalModel createChild(PropertyDescriptor property);
 
-    HierarchicalModel createChild(String property, Object value);
+    HierarchicalModel createChild(String property);
 
-    HierarchicalModel createList(PropertyDescriptor property, Object value);
+    HierarchicalModel createList(PropertyDescriptor property);
 
-    HierarchicalModel createList(String property, Object value);
+    HierarchicalModel createList(String property);
 }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModelEntityCounter.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModelEntityCounter.java
@@ -18,17 +18,17 @@ public class HierarchicalModelEntityCounter implements HierarchicalModelObserver
 
     @Override
     public void addedSimple(String name, Object value) {
+//        countAndCheck();
+    }
+
+    @Override
+    public void createdChild(String name) {
         countAndCheck();
     }
 
     @Override
-    public void createdChild(String name, Object value) {
-        countAndCheck();
-    }
-
-    @Override
-    public void createdList(String name, Object value) {
-        countAndCheck();
+    public void createdList(String name) {
+//        countAndCheck();
     }
 
     private void countAndCheck() {

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModelEntityCounter.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModelEntityCounter.java
@@ -1,0 +1,49 @@
+package org.skyscreamer.yoga.mapper;
+
+import org.skyscreamer.yoga.util.EntityCountExceededException;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: Carter Page
+ * Date: 3/31/12
+ * Time: 5:21 PM
+ */
+public class HierarchicalModelEntityCounter implements HierarchicalModelObserver {
+    private int _count = 0;
+    private final int _maxEntities;
+
+    public HierarchicalModelEntityCounter(int maxEntities) {
+        _maxEntities = maxEntities;
+    }
+
+    @Override
+    public void addedSimple(String name, Object value) {
+        countAndCheck();
+    }
+
+    @Override
+    public void createdChild(String name, Object value) {
+        countAndCheck();
+    }
+
+    @Override
+    public void createdList(String name, Object value) {
+        countAndCheck();
+    }
+
+    private void countAndCheck() {
+        ++_count;
+        if (_maxEntities > -1 && _count > _maxEntities) {
+            throw new EntityCountExceededException("Exceeded maximum limit of " + _maxEntities + " entities " +
+                    "in a single model");
+        }
+    }
+
+    public int getCount() {
+        return _count;
+    }
+
+    public int getMaxEntities() {
+        return _maxEntities;
+    }
+}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModelEntityCounter.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModelEntityCounter.java
@@ -9,10 +9,11 @@ import org.skyscreamer.yoga.util.EntityCountExceededException;
  * Time: 5:21 PM
  */
 public class HierarchicalModelEntityCounter implements HierarchicalModelObserver {
-    private int _count = 0;
+    private final ResultTraverserContext _context;
     private final int _maxEntities;
 
-    public HierarchicalModelEntityCounter(int maxEntities) {
+    public HierarchicalModelEntityCounter(ResultTraverserContext context, int maxEntities) {
+        _context = context;
         _maxEntities = maxEntities;
     }
 
@@ -32,15 +33,15 @@ public class HierarchicalModelEntityCounter implements HierarchicalModelObserver
     }
 
     private void countAndCheck() {
-        ++_count;
-        if (_maxEntities > -1 && _count > _maxEntities) {
+        _context.incrementCounter();
+        if (_maxEntities > -1 && _context.readCounter() > _maxEntities) {
             throw new EntityCountExceededException("Exceeded maximum limit of " + _maxEntities + " entities " +
                     "in a single model");
         }
     }
 
     public int getCount() {
-        return _count;
+        return _context.readCounter();
     }
 
     public int getMaxEntities() {

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModelObserver.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModelObserver.java
@@ -2,6 +2,6 @@ package org.skyscreamer.yoga.mapper;
 
 public interface HierarchicalModelObserver {
     void addedSimple(String name, Object value);
-    void createdChild(String name, Object value);
-    void createdList(String name, Object value);
+    void createdChild(String name);
+    void createdList(String name);
 }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModelObserver.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/HierarchicalModelObserver.java
@@ -1,0 +1,7 @@
+package org.skyscreamer.yoga.mapper;
+
+public interface HierarchicalModelObserver {
+    void addedSimple(String name, Object value);
+    void createdChild(String name, Object value);
+    void createdList(String name, Object value);
+}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ObservedHierarchicalModel.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ObservedHierarchicalModel.java
@@ -1,0 +1,70 @@
+package org.skyscreamer.yoga.mapper;
+
+import java.beans.PropertyDescriptor;
+import java.util.List;
+
+/**
+ * Wrapper class that allows a model to be observed as it is constructed.
+ */
+public class ObservedHierarchicalModel implements HierarchicalModel {
+    private final HierarchicalModel _hierHierarchicalModel;
+    private final HierarchicalModelObserver[] _observers;
+
+    public ObservedHierarchicalModel(HierarchicalModel hierarchicalModel, HierarchicalModelObserver... observers) {
+        _hierHierarchicalModel = hierarchicalModel;
+        for(HierarchicalModelObserver observer : observers) {
+            if (observer == null) {
+                throw new NullPointerException("Null observer not allowed");
+            }
+        }
+        _observers = observers;
+    }
+
+    @Override
+    public void addSimple(PropertyDescriptor property, Object value) {
+        _hierHierarchicalModel.addSimple(property, value);
+        for(HierarchicalModelObserver observer : _observers) {
+            observer.addedSimple(property.getName(), value);
+        }
+    }
+
+    @Override
+    public void addSimple(String name, Object value) {
+        _hierHierarchicalModel.addSimple(name, value);
+        for(HierarchicalModelObserver observer : _observers) {
+            observer.addedSimple(name, value);
+        }
+    }
+
+    @Override
+    public HierarchicalModel createChild(PropertyDescriptor property, Object value) {
+        for(HierarchicalModelObserver observer : _observers) {
+            observer.createdChild(property.getName(), value);
+        }
+        return new ObservedHierarchicalModel(_hierHierarchicalModel.createChild(property, value), _observers);
+    }
+
+    @Override
+    public HierarchicalModel createChild(String name, Object value) {
+        for(HierarchicalModelObserver observer : _observers) {
+            observer.createdChild(name, value);
+        }
+        return new ObservedHierarchicalModel(_hierHierarchicalModel.createChild(name, value), _observers);
+    }
+
+    @Override
+    public HierarchicalModel createList(PropertyDescriptor property, Object value) {
+        for(HierarchicalModelObserver observer : _observers) {
+            observer.createdList(property.getName(), value);
+        }
+        return new ObservedHierarchicalModel(_hierHierarchicalModel.createList(property, value), _observers);
+    }
+
+    @Override
+    public HierarchicalModel createList(String name, Object value) {
+        for(HierarchicalModelObserver observer : _observers) {
+            observer.createdList(name, value);
+        }
+        return new ObservedHierarchicalModel(_hierHierarchicalModel.createList(name, value), _observers);
+    }
+}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ObservedHierarchicalModel.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ObservedHierarchicalModel.java
@@ -37,34 +37,34 @@ public class ObservedHierarchicalModel implements HierarchicalModel {
     }
 
     @Override
-    public HierarchicalModel createChild(PropertyDescriptor property, Object value) {
+    public HierarchicalModel createChild(PropertyDescriptor property) {
         for(HierarchicalModelObserver observer : _observers) {
-            observer.createdChild(property.getName(), value);
+            observer.createdChild(property.getName());
         }
-        return new ObservedHierarchicalModel(_hierHierarchicalModel.createChild(property, value), _observers);
+        return new ObservedHierarchicalModel(_hierHierarchicalModel.createChild(property), _observers);
     }
 
     @Override
-    public HierarchicalModel createChild(String name, Object value) {
+    public HierarchicalModel createChild(String name) {
         for(HierarchicalModelObserver observer : _observers) {
-            observer.createdChild(name, value);
+            observer.createdChild(name);
         }
-        return new ObservedHierarchicalModel(_hierHierarchicalModel.createChild(name, value), _observers);
+        return new ObservedHierarchicalModel(_hierHierarchicalModel.createChild(name), _observers);
     }
 
     @Override
-    public HierarchicalModel createList(PropertyDescriptor property, Object value) {
+    public HierarchicalModel createList(PropertyDescriptor property) {
         for(HierarchicalModelObserver observer : _observers) {
-            observer.createdList(property.getName(), value);
+            observer.createdList(property.getName());
         }
-        return new ObservedHierarchicalModel(_hierHierarchicalModel.createList(property, value), _observers);
+        return new ObservedHierarchicalModel(_hierHierarchicalModel.createList(property), _observers);
     }
 
     @Override
-    public HierarchicalModel createList(String name, Object value) {
+    public HierarchicalModel createList(String name) {
         for(HierarchicalModelObserver observer : _observers) {
-            observer.createdList(name, value);
+            observer.createdList(name);
         }
-        return new ObservedHierarchicalModel(_hierHierarchicalModel.createList(name, value), _observers);
+        return new ObservedHierarchicalModel(_hierHierarchicalModel.createList(name), _observers);
     }
 }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ResultTraverser.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ResultTraverser.java
@@ -27,7 +27,7 @@ import org.skyscreamer.yoga.selector.Selector;
  */
 public class ResultTraverser
 {
-   
+   private int _maxEntities = -1;
    private FieldPopulatorRegistry _fieldPopulatorRegistry = new DefaultFieldPopulatorRegistry(
          new ArrayList<FieldPopulator<?>>() );
    private List<Enricher> _enrichers = Arrays.asList(new HrefEnricher(), new ModelDefinitionBuilder(), new NavigationLinksEnricher());
@@ -42,6 +42,9 @@ public class ResultTraverser
    public void traverse(Object instance, Selector fieldSelector, HierarchicalModel model,
          String hrefSuffix, HttpServletResponse response)
    {
+      if (_maxEntities > -1) {
+          model = new ObservedHierarchicalModel(model, new HierarchicalModelEntityCounter(_maxEntities));
+      }
       Class<?> instanceType = findClass( instance );
       addExtraInfo( response, instance, fieldSelector, model, instanceType, hrefSuffix );
       addProperties( response, instance, fieldSelector, model, instanceType, hrefSuffix );
@@ -152,7 +155,7 @@ public class ResultTraverser
       {
          return;
       }
-      HierarchicalModel listModel = model.createList( property, list );
+      HierarchicalModel listModel = model.createList( property );
       for (Object o : list)
       {
          Class<?> type = findClass( o );
@@ -174,7 +177,7 @@ public class ResultTraverser
       {
          return;
       }
-      HierarchicalModel listModel = model.createList( property, list );
+      HierarchicalModel listModel = model.createList( property );
       for (Object o : list)
       {
          Class<?> type = findClass( o );
@@ -192,14 +195,14 @@ public class ResultTraverser
    private void traverseChild(HttpServletResponse response, Selector parentSelector,
          HierarchicalModel parent, PropertyDescriptor property, Object value, String hrefSuffix)
    {
-      traverse( value, parentSelector.getField( property ), parent.createChild( property, value ),
+      traverse( value, parentSelector.getField( property ), parent.createChild( property ),
             hrefSuffix, response );
    }
 
    private void traverseChild(HttpServletResponse response, Selector parentSelector, HierarchicalModel parent,
          String property, Object value, String hrefSuffix)
    {
-      traverse( value, parentSelector.getField( property ), parent.createChild( property, value ),
+      traverse( value, parentSelector.getField( property ), parent.createChild( property ),
             hrefSuffix, response );
    }
 
@@ -229,4 +232,12 @@ public class ResultTraverser
    {
       this._enrichers = enrichers;
    }
+
+    public int getMaxEntities() {
+        return _maxEntities;
+    }
+
+    public void setMaxEntities(int _maxEntities) {
+        this._maxEntities = _maxEntities;
+    }
 }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ResultTraverser.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ResultTraverser.java
@@ -41,7 +41,7 @@ public class ResultTraverser
          ResultTraverserContext context)
    {
       if (_maxEntities > -1) {
-          model = new ObservedHierarchicalModel(model, new HierarchicalModelEntityCounter(_maxEntities));
+          model = new ObservedHierarchicalModel(model, new HierarchicalModelEntityCounter(context, _maxEntities));
       }
       Class<?> instanceType = findClass( instance );
       addExtraInfo( instance, fieldSelector, model, instanceType, context );

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ResultTraverserContext.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ResultTraverserContext.java
@@ -1,12 +1,15 @@
 package org.skyscreamer.yoga.mapper;
 
 import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ResultTraverserContext
 {
-   private String hrefSuffix;
-   private HttpServletResponse response;
-
+   private final String hrefSuffix;
+   private final HttpServletResponse response;
+   private final Map<String, Object> properties = new HashMap<String, Object>();
+   private int counter = 0;
 
    public ResultTraverserContext(String hrefSuffix, HttpServletResponse response)
    {
@@ -19,19 +22,24 @@ public class ResultTraverserContext
       return hrefSuffix;
    }
 
-   public void setHrefSuffix(String hrefSuffix)
-   {
-      this.hrefSuffix = hrefSuffix;
-   }
-
    public HttpServletResponse getResponse()
    {
       return response;
    }
-
-   public void setResponse(HttpServletResponse response)
-   {
-      this.response = response;
+    
+   public void setProperty(String key, Object value) {
+       properties.put(key, value);
    }
-
+    
+   public Object getProperty(String key) {
+       return properties.get(key);
+   }
+   
+   public void incrementCounter() {
+       ++counter;
+   }
+    
+   public int readCounter() {
+       return counter;
+   }
 }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/XhtmlHierarchyModel.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/XhtmlHierarchyModel.java
@@ -49,29 +49,28 @@ public class XhtmlHierarchyModel implements HierarchicalModel
    }
 
    @Override
-   public HierarchicalModel createChild(PropertyDescriptor property, Object result)
+   public HierarchicalModel createChild(PropertyDescriptor property)
    {
-      return createChild(property.getName(), result);
+      return createChild(property.getName());
    }
 
    @Override
-   public HierarchicalModel createChild(String property, Object value)
+   public HierarchicalModel createChild(String property)
    {
       return new XhtmlHierarchyModel(element.addElement("div").addAttribute("class",
             property));
    }
    
    @Override
-   public HierarchicalModel createList(PropertyDescriptor property, Object result)
+   public HierarchicalModel createList(PropertyDescriptor property)
    {
-      return createList( property.getName(), result );
+      return createList( property.getName());
    }
 
    @Override
-   public HierarchicalModel createList(String property, Object result)
+   public HierarchicalModel createList(String property)
    {
       Element div = element.addElement("div").addAttribute("class", property);
-      String name = NameUtil.getName(result.getClass());
-      return new XhtmlHierarchyModel(div, name);
+      return new XhtmlHierarchyModel(div, property);
    }
 }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/XmlHierarchyModel.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/XmlHierarchyModel.java
@@ -42,24 +42,24 @@ public class XmlHierarchyModel implements HierarchicalModel
    }
    
    @Override
-   public HierarchicalModel createChild(PropertyDescriptor property, Object result)
+   public HierarchicalModel createChild(PropertyDescriptor property)
    {
-      return createChild( property.getName(), result );
+      return createChild( property.getName());
    }
 
-   public HierarchicalModel createChild(String name, Object result)
+   public HierarchicalModel createChild(String name)
    {
       return new XmlHierarchyModel(element.addElement(name));
    }
 
    @Override
-   public HierarchicalModel createList(PropertyDescriptor property, Object result)
+   public HierarchicalModel createList(PropertyDescriptor property)
    {
-      return createList( property.getName(), result );
+      return createList( property.getName());
    }
    
    @Override
-   public HierarchicalModel createList(String property, Object result)
+   public HierarchicalModel createList(String property)
    {
       return this;
    }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/enrich/MetadataLinkEnricher.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/enrich/MetadataLinkEnricher.java
@@ -26,7 +26,7 @@ public class MetadataLinkEnricher implements Enricher
          return;
       }
 
-      HierarchicalModel metaDataLink = model.createChild( "metadata", "useless parameter" );
+      HierarchicalModel metaDataLink = model.createChild( "metadata" );
       metaDataLink.addSimple( "href", metaDataService.getHref( instanceType, hrefSuffix ) );
    }
 

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/enrich/NavigationLinksEnricher.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/enrich/NavigationLinksEnricher.java
@@ -30,13 +30,12 @@ public class NavigationLinksEnricher implements Enricher
       }
 
       HierarchicalModel navigationLinks = model
-            .createChild( "navigationLinks", "useless parameter" );
+            .createChild( "navigationLinks");
       for (PropertyDescriptor property : PropertyUtil.getReadableProperties( instanceType ))
       {
          if (!fieldSelector.containsField( property, populator ))
          {
-            HierarchicalModel propertyLink = navigationLinks.createChild( property,
-                  "another useless parameter" );
+            HierarchicalModel propertyLink = navigationLinks.createChild( property );
             propertyLink.addSimple( "name", property.getName() );
             String hrefSuffixAndSelector = hrefSuffix + "?selector=:(" + property.getName() + ")";
             hrefEnricher.enrich( response, instance, fieldSelector, propertyLink,

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/util/EntityCountExceededException.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/util/EntityCountExceededException.java
@@ -1,0 +1,17 @@
+package org.skyscreamer.yoga.util;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: Carter Page
+ * Date: 3/31/12
+ * Time: 5:26 PM
+ */
+public class EntityCountExceededException extends RuntimeException {
+    public EntityCountExceededException() {
+        super();
+    }
+
+    public EntityCountExceededException(String s) {
+        super(s);
+    }
+}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/util/GzippedResource.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/util/GzippedResource.java
@@ -1,0 +1,84 @@
+package org.skyscreamer.yoga.util;
+
+import org.springframework.core.io.Resource;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Wraps a gzipped Resource so that it decompresses on the fly.
+ *
+ * @author Carter Page
+ */
+public class GzippedResource implements Resource {
+    private final Resource _resource;
+    
+    public GzippedResource(Resource resource) {
+        _resource = resource;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return new GZIPInputStream(_resource.getInputStream());
+    }
+
+    // Delegate Methods
+    @Override
+    public boolean exists() {
+        return _resource.exists();
+    }
+
+    @Override
+    public boolean isReadable() {
+        return _resource.isReadable();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return _resource.isOpen();
+    }
+
+    @Override
+    public URL getURL() throws IOException {
+        return _resource.getURL();
+    }
+
+    @Override
+    public URI getURI() throws IOException {
+        return _resource.getURI();
+    }
+
+    @Override
+    public File getFile() throws IOException {
+        return _resource.getFile();
+    }
+
+    @Override
+    public long contentLength() throws IOException {
+        return _resource.contentLength();
+    }
+
+    @Override
+    public long lastModified() throws IOException {
+        return _resource.lastModified();
+    }
+
+    @Override
+    public Resource createRelative(String relativePath) throws IOException {
+        return _resource.createRelative(relativePath);
+    }
+
+    @Override
+    public String getFilename() {
+        return _resource.getFilename();
+    }
+
+    @Override
+    public String getDescription() {
+        return _resource.getDescription();
+    }
+}

--- a/yoga-demos/yoga-demo-resteasy/src/test/java/org/skyscreamer/yoga/demo/test/resteasy/UserControllerTest.java
+++ b/yoga-demos/yoga-demo-resteasy/src/test/java/org/skyscreamer/yoga/demo/test/resteasy/UserControllerTest.java
@@ -2,6 +2,7 @@ package org.skyscreamer.yoga.demo.test.resteasy;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.skyscreamer.yoga.util.EntityCountExceededException;
 
 /**
  * Created by IntelliJ IDEA.
@@ -29,6 +30,11 @@ public class UserControllerTest extends org.skyscreamer.yoga.demo.test.UserContr
     @Test
     public void testGetUsers() throws Exception {
         super.testGetUsers();
+    }
+
+    @Test
+    public void testGetTooMuchData() throws Exception {
+        super.testGetTooMuchData();
     }
 
     @Test

--- a/yoga-demos/yoga-demo-shared/src/main/java/org/skyscreamer/yoga/demo/test/AbstractTest.java
+++ b/yoga-demos/yoga-demo-shared/src/main/java/org/skyscreamer/yoga/demo/test/AbstractTest.java
@@ -3,7 +3,10 @@ package org.skyscreamer.yoga.demo.test;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.web.client.RestTemplate;
 
@@ -14,16 +17,17 @@ import org.springframework.web.client.RestTemplate;
  * Time: 6:18 PM
  */
 public abstract class AbstractTest {
+    protected final Log _log = LogFactory.getLog(getClass());
 
-    protected JSONObject getJSONObject(String url, Map<String, String> params) throws Exception {
+    protected JSONObject getJSONObject(String url, Map<String, String> params) throws JSONException {
         return new JSONObject(getContent(url, params));
     }
 
-    protected JSONArray getJSONArray(String url, Map<String, String> params) throws Exception {
+    protected JSONArray getJSONArray(String url, Map<String, String> params) throws JSONException {
         return new JSONArray(getContent(url, params));
     }
 
-    private String getContent(String url, Map<String, String> params) throws Exception {
+    private String getContent(String url, Map<String, String> params) {
         RestTemplate restTemplate = new RestTemplate();
         StringBuilder sb = new StringBuilder("http://localhost:8082").append(url).append(".json");
         addParams(params, sb);

--- a/yoga-demos/yoga-demo-shared/src/main/java/org/skyscreamer/yoga/demo/test/UserControllerTest.java
+++ b/yoga-demos/yoga-demo-shared/src/main/java/org/skyscreamer/yoga/demo/test/UserControllerTest.java
@@ -4,11 +4,14 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.yoga.util.EntityCountExceededException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 
 /**
  * Created by IntelliJ IDEA.
@@ -72,4 +75,17 @@ public class UserControllerTest extends AbstractTest {
         Assert.assertNotNull(recommended);
     }
 
+    // This should retrieve a LOT of data and throw EntityCountExceededException
+    public void testGetTooMuchData() throws Exception {
+        Map<String, String> params = Collections.singletonMap("selector", ":(friends:(favoriteArtists))");
+        try {
+            getJSONObject("/user", params);
+        }
+        catch (HttpServerErrorException e) {
+            Assert.assertNotNull(e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("EntityCountExceededException"));
+            return;
+        }
+        Assert.fail("Expected this query to fail with a 500 error caused by an EntityCountExceededException");
+    }
 }

--- a/yoga-demos/yoga-demo-shared/src/main/java/org/skyscreamer/yoga/demo/test/UserControllerTest.java
+++ b/yoga-demos/yoga-demo-shared/src/main/java/org/skyscreamer/yoga/demo/test/UserControllerTest.java
@@ -35,9 +35,7 @@ public class UserControllerTest extends AbstractTest {
 
     public void testGetUsers() throws Exception {
         JSONArray data = getJSONArray("/user", null);
-        JSONAssert.assertEquals("[{name:\"Carter Page\",id:1,href:\"/user/1.json\"}," +
-                "{name:\"Corby Page\",id:2,href:\"/user/2.json\"}," +
-                "{name:\"Solomon Duskis\",id:3,href:\"/user/3.json\"}]", data, false);
+        Assert.assertEquals(1003, data.length());
     }
 
     public void testGetUserWithSelector() throws Exception {

--- a/yoga-demos/yoga-demo-shared/src/main/resources/applicationContext.xml
+++ b/yoga-demos/yoga-demo-shared/src/main/resources/applicationContext.xml
@@ -44,19 +44,22 @@
 		p:scripts="classpath:sampledb.sql" />
 
     <!-- This is for loading large quantities of data for testing data scaling.  Disabled by default. -->
-    <bean id="loadDbInit"
+    <bean id="extendedDbInit"
           class="org.springframework.jdbc.datasource.init.DataSourceInitializer"
-          p:dataSource-ref="dataSource" p:databasePopulator-ref="loadDbPopulator"
-          depends-on="sessionFactory"
-          p:enabled="false" />
+          p:dataSource-ref="dataSource" p:databasePopulator-ref="extendedDbPopulator"
+          depends-on="sessionFactory" />
 
-    <bean id="loadDbResource" class="org.springframework.core.io.UrlResource">
-        <constructor-arg value="https://raw.github.com/skyscreamer/skyscreamer.github.com/master/yoga/loaddb.sql" />
+    <bean id="extendedDbResource" class="org.skyscreamer.yoga.util.GzippedResource">
+        <constructor-arg>
+            <bean class="org.springframework.core.io.UrlResource">
+                <constructor-arg value="https://raw.github.com/skyscreamer/skyscreamer.github.com/master/yoga/loaddb.sql.gz" />
+            </bean>
+        </constructor-arg>
     </bean>
 
-    <bean id="loadDbPopulator"
+    <bean id="extendedDbPopulator"
           class="org.springframework.jdbc.datasource.init.ResourceDatabasePopulator"
-          p:scripts-ref="loadDbResource" />
+          p:scripts-ref="extendedDbResource" />
 
 	<bean id="transactionManager"
 		class="org.springframework.jdbc.datasource.DataSourceTransactionManager"

--- a/yoga-demos/yoga-demo-shared/src/main/resources/applicationContext.xml
+++ b/yoga-demos/yoga-demo-shared/src/main/resources/applicationContext.xml
@@ -67,7 +67,8 @@
 
 	<bean id="resultTraverser" class="org.skyscreamer.yoga.mapper.ResultTraverser"
 		p:fieldPopulatorRegistry-ref="fieldPopulatorRegistry"
-		p:classFinderStrategy-ref="hibernateClassFinder">
+		p:classFinderStrategy-ref="hibernateClassFinder"
+        p:maxEntities="1000">
 		<property name="enrichers">
 			<list>
 				<bean class="org.skyscreamer.yoga.mapper.enrich.HrefEnricher"/>

--- a/yoga-demos/yoga-demo-shared/src/main/resources/applicationContext.xml
+++ b/yoga-demos/yoga-demo-shared/src/main/resources/applicationContext.xml
@@ -68,7 +68,7 @@
 	<bean id="resultTraverser" class="org.skyscreamer.yoga.mapper.ResultTraverser"
 		p:fieldPopulatorRegistry-ref="fieldPopulatorRegistry"
 		p:classFinderStrategy-ref="hibernateClassFinder"
-        p:maxEntities="1000">
+        p:maxEntities="100000">
 		<property name="enrichers">
 			<list>
 				<bean class="org.skyscreamer.yoga.mapper.enrich.HrefEnricher"/>

--- a/yoga-demos/yoga-demo-springmvc/src/test/java/org/skyscreamer/yoga/demo/test/springmvc/UserControllerTest.java
+++ b/yoga-demos/yoga-demo-springmvc/src/test/java/org/skyscreamer/yoga/demo/test/springmvc/UserControllerTest.java
@@ -2,6 +2,7 @@ package org.skyscreamer.yoga.demo.test.springmvc;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.skyscreamer.yoga.util.EntityCountExceededException;
 
 /**
  * Created by IntelliJ IDEA.
@@ -29,6 +30,11 @@ public class UserControllerTest extends org.skyscreamer.yoga.demo.test.UserContr
     @Test
     public void testGetUsers() throws Exception {
         super.testGetUsers();
+    }
+
+    @Test
+    public void testGetTooMuchData() throws Exception {
+        super.testGetTooMuchData();
     }
 
     @Test

--- a/yoga-integration/yoga-springmvc/src/main/java/org/skyscreamer/yoga/springmvc/view/JsonSelectorView.java
+++ b/yoga-integration/yoga-springmvc/src/main/java/org/skyscreamer/yoga/springmvc/view/JsonSelectorView.java
@@ -20,18 +20,19 @@ public class JsonSelectorView extends AbstractYogaView
          throws IOException
    {
       Object viewData;
+      ResultTraverserContext context = new ResultTraverserContext(getHrefSuffix(), response);
       if (value instanceof Iterable<?>)
       {
          List<Map<String, Object>> list = new ArrayList<Map<String, Object>>();
          for (Object instance : (Iterable<?>) value)
          {
-            list.add(getSingleResult(response, instance, selector));
+            list.add(getSingleResult(instance, selector, context));
          }
          viewData = list;
       }
       else
       {
-         viewData = getSingleResult(response, value, selector);
+         viewData = getSingleResult(value, selector, context);
       }
       getObjectMapper().writeValue(outputStream, viewData);
    }
@@ -41,10 +42,10 @@ public class JsonSelectorView extends AbstractYogaView
       return new ObjectMapper();
    }
 
-   protected Map<String, Object> getSingleResult(HttpServletResponse response, Object value, Selector selector)
+   protected Map<String, Object> getSingleResult(Object value, Selector selector, ResultTraverserContext context)
    {
       MapHierarchicalModel model = new MapHierarchicalModel();
-      resultTraverser.traverse(value, selector, model, new ResultTraverserContext(getHrefSuffix(), response));
+      resultTraverser.traverse(value, selector, model, context);
       return model.getObjectTree();
    }
 

--- a/yoga-integration/yoga-springmvc/src/main/java/org/skyscreamer/yoga/springmvc/view/XhtmlSelectorView.java
+++ b/yoga-integration/yoga-springmvc/src/main/java/org/skyscreamer/yoga/springmvc/view/XhtmlSelectorView.java
@@ -22,6 +22,8 @@ public class XhtmlSelectorView extends AbstractYogaView
    public void render(OutputStream outputStream, Selector selector, Object value, HttpServletResponse response)
          throws IOException
    {
+      ResultTraverserContext context = new ResultTraverserContext(getHrefSuffix(), response);
+
       DOMDocument domDocument = new DOMDocument();
       Element rootElement = new DOMElement( "html" );
       domDocument.setRootElement( rootElement );
@@ -34,22 +36,22 @@ public class XhtmlSelectorView extends AbstractYogaView
       {
          for (Object child : (Iterable<?>) value)
          {
-            traverse( response, child, selector, resultTraverser, body );
+            traverse( child, selector, resultTraverser, body, context );
          }
       }
       else
       {
-         traverse( response, value, selector, resultTraverser, body );
+         traverse( value, selector, resultTraverser, body, context );
       }
       write( outputStream, domDocument );
    }
 
-   public void traverse(HttpServletResponse response, Object value, Selector selector, ResultTraverser traverser, Element body)
+   public void traverse(Object value, Selector selector, ResultTraverser traverser, Element body, ResultTraverserContext context)
    {
       String name = NameUtil.getName( traverser.findClass( value ) );
       HierarchicalModel model = new XhtmlHierarchyModel( body.addElement( "div" ).addAttribute(
             "class", name ) );
-      traverser.traverse( value, selector, model, new ResultTraverserContext(getHrefSuffix(), response) );
+      traverser.traverse( value, selector, model, context );
    }
 
    @Override

--- a/yoga-integration/yoga-springmvc/src/main/java/org/skyscreamer/yoga/springmvc/view/XmlSelectorView.java
+++ b/yoga-integration/yoga-springmvc/src/main/java/org/skyscreamer/yoga/springmvc/view/XmlSelectorView.java
@@ -19,6 +19,8 @@ public class XmlSelectorView extends AbstractYogaView
    public void render(OutputStream outputStream, Selector selector, Object value, HttpServletResponse response)
          throws IOException
    {
+      ResultTraverserContext context = new ResultTraverserContext(getHrefSuffix(), response);
+
       DOMDocument domDocument = new DOMDocument();
       if (value instanceof Iterable)
       {
@@ -26,14 +28,14 @@ public class XmlSelectorView extends AbstractYogaView
          HierarchicalModel model = new XmlHierarchyModel( root );
          for (Object child : (Iterable<?>) value)
          {
-            resultTraverser.traverse( child, selector, model, new ResultTraverserContext( getHrefSuffix(), response ) );
+            resultTraverser.traverse( child, selector, model, context );
          }
       }
       else
       {
          String name = NameUtil.getName( resultTraverser.findClass( value ) );
          DOMElement root = createDocument( domDocument, name );
-         resultTraverser.traverse( value, selector, new XmlHierarchyModel( root ), new ResultTraverserContext( getHrefSuffix(), response ) );
+         resultTraverser.traverse( value, selector, new XmlHierarchyModel( root ), context );
       }
       write( outputStream, domDocument );
    }


### PR DESCRIPTION
- Allows server to kill queries that collect over a certain # of entities during traversal.  (Defaults to 100k in demo.)
- Got rid of value field in HeirarchicalModel.createChild and .createList
