### PR TITLE
Consolidated use of Listener for class names

### DIFF
--- a/yoga-core/src/main/java/org/skyscreamer/yoga/enricher/Enricher.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/enricher/Enricher.java
@@ -1,7 +1,0 @@
-package org.skyscreamer.yoga.enricher;
-
-import org.skyscreamer.yoga.listener.RenderingListener;
-
-public interface Enricher extends RenderingListener
-{
-}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/listener/HrefListener.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/listener/HrefListener.java
@@ -1,4 +1,4 @@
-package org.skyscreamer.yoga.enricher;
+package org.skyscreamer.yoga.listener;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.skyscreamer.yoga.annotations.URITemplate;
@@ -16,17 +16,17 @@ import org.skyscreamer.yoga.util.ValueReader;
 import javax.servlet.http.HttpServletResponse;
 import java.lang.reflect.Method;
 
-public class HrefEnricher implements RenderingListener
+public class HrefListener implements RenderingListener
 {
 
     private URICreator _uriCreator = new URICreator();
     private FieldPopulatorRegistry _fieldPopulatorRegistry = null;
 
-    public HrefEnricher()
+    public HrefListener()
     {
     }
 
-    public HrefEnricher( FieldPopulatorRegistry _fieldPopulatorRegistry )
+    public HrefListener( FieldPopulatorRegistry _fieldPopulatorRegistry )
     {
         this._fieldPopulatorRegistry = _fieldPopulatorRegistry;
     }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/listener/MetadataLinkListener.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/listener/MetadataLinkListener.java
@@ -1,4 +1,4 @@
-package org.skyscreamer.yoga.enricher;
+package org.skyscreamer.yoga.listener;
 
 import org.skyscreamer.yoga.listener.RenderingEvent;
 import org.skyscreamer.yoga.listener.RenderingEventType;
@@ -6,7 +6,7 @@ import org.skyscreamer.yoga.listener.RenderingListener;
 import org.skyscreamer.yoga.metadata.MetaDataService;
 import org.skyscreamer.yoga.model.MapHierarchicalModel;
 
-public class MetadataLinkEnricher implements RenderingListener
+public class MetadataLinkListener implements RenderingListener
 {
     private MetaDataService metaDataService;
 

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/listener/ModelDefinitionListener.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/listener/ModelDefinitionListener.java
@@ -1,4 +1,4 @@
-package org.skyscreamer.yoga.enricher;
+package org.skyscreamer.yoga.listener;
 
 import static org.skyscreamer.yoga.populator.FieldPopulatorUtil.getPopulatorExtraFieldMethods;
 
@@ -16,9 +16,8 @@ import org.skyscreamer.yoga.model.MapHierarchicalModel;
 import org.skyscreamer.yoga.populator.FieldPopulatorRegistry;
 import org.skyscreamer.yoga.selector.parser.SelectorParser;
 
-public class ModelDefinitionBuilder implements RenderingListener
+public class ModelDefinitionListener implements RenderingListener
 {
-
     private FieldPopulatorRegistry fieldPopulatorRegistry;
 
     public void setFieldPopulatorRegistry( FieldPopulatorRegistry fieldPopulatorRegistry )
@@ -56,5 +55,4 @@ public class ModelDefinitionBuilder implements RenderingListener
         }
         ( ( MapHierarchicalModel<?>) event.getModel()).addProperty( SelectorParser.DEFINITION, definition );
     }
-
 }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/listener/NavigationLinksListener.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/listener/NavigationLinksListener.java
@@ -1,24 +1,20 @@
-package org.skyscreamer.yoga.enricher;
+package org.skyscreamer.yoga.listener;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.skyscreamer.yoga.listener.RenderingEvent;
-import org.skyscreamer.yoga.listener.RenderingEventType;
-import org.skyscreamer.yoga.listener.RenderingListener;
 import org.skyscreamer.yoga.model.MapHierarchicalModel;
 import org.skyscreamer.yoga.selector.Property;
 import org.skyscreamer.yoga.selector.Selector;
 
-public class NavigationLinksEnricher implements RenderingListener
+public class NavigationLinksListener implements RenderingListener
 {
+    private HrefListener _hrefListener = new HrefListener();
 
-    private HrefEnricher hrefEnricher = new HrefEnricher();
-
-    public void setHrefEnricher( HrefEnricher hrefEnricher )
+    public void setHrefListener( HrefListener hrefListener )
     {
-        this.hrefEnricher = hrefEnricher;
+        this._hrefListener = hrefListener;
     }
 
     @Override
@@ -45,7 +41,7 @@ public class NavigationLinksEnricher implements RenderingListener
             MapHierarchicalModel<?> navModel = navigationLinks.createChildMap( fieldName );
             String hrefSuffixAndSelector = String
                     .format( "%s?selector=:(%s)", urlSuffix, fieldName );
-            hrefEnricher.addUrl( instance, instanceType, hrefSuffixAndSelector, navModel,
+            _hrefListener.addUrl( instance, instanceType, hrefSuffixAndSelector, navModel,
                     event.getRequestContext() );
             navModel.addProperty( "name", fieldName );
         }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/listener/SelectorBuilderListener.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/listener/SelectorBuilderListener.java
@@ -1,13 +1,11 @@
-package org.skyscreamer.yoga.enricher;
+package org.skyscreamer.yoga.listener;
 
-import org.skyscreamer.yoga.listener.RenderingEvent;
-import org.skyscreamer.yoga.listener.RenderingEventType;
 import org.skyscreamer.yoga.model.MapHierarchicalModel;
 
 /**
  * Created by IntelliJ IDEA. User: cpage Date: 12/10/11 Time: 3:59 PM
  */
-public class SelectorBuilderEnricher extends HrefEnricher
+public class SelectorBuilderListener extends HrefListener
 {
     public static final String FIELD_NAME = "selectorBuilder";
 

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/util/DefaultClassFinderStrategy.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/util/DefaultClassFinderStrategy.java
@@ -2,11 +2,9 @@ package org.skyscreamer.yoga.util;
 
 public class DefaultClassFinderStrategy implements ClassFinderStrategy
 {
-
     @Override
     public Class<?> findClass( Object instance )
     {
         return instance == null ? null : instance.getClass();
     }
-
 }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/util/NameUtil.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/util/NameUtil.java
@@ -5,8 +5,7 @@ public class NameUtil
     public static String getName( Class<?> type )
     {
         String name = getFormalName( type );
-        return new StringBuilder().append( Character.toLowerCase( name.charAt( 0 ) ) )
-                .append( name.substring( 1 ) ).toString();
+        return String.valueOf( Character.toLowerCase( name.charAt( 0 ) ) ) + name.substring( 1 );
     }
 
     public static String getFormalName( Class<?> type )

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/util/ObjectUtil.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/util/ObjectUtil.java
@@ -1,9 +1,7 @@
 package org.skyscreamer.yoga.util;
 
-
 public class ObjectUtil
 {
-
     public static boolean isPrimitive( Class<?> clazz )
     {
         return clazz.isPrimitive() || clazz.isEnum() || Number.class.isAssignableFrom( clazz )

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/util/ParenthesisUtil.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/util/ParenthesisUtil.java
@@ -24,12 +24,7 @@ public class ParenthesisUtil
      * @param selector String to analyze for the matching selector
      * @param index    Index of the opening parenthesis to match
      * @return Index of matching closing parenthesis
-<<<<<<< HEAD
      * @throws org.skyscreamer.yoga.exceptions.ParseSelectorException
-=======
-     * @throws org.skyscreamer.yoga.selector.ParseSelectorException
-     *
->>>>>>> upstream/master
      */
     public static int getMatchingParenthesisIndex( CharSequence selector, int index ) throws ParseSelectorException
     {

--- a/yoga-core/src/test/java/org/skyscreamer/yoga/listener/HrefListenerTest.java
+++ b/yoga-core/src/test/java/org/skyscreamer/yoga/listener/HrefListenerTest.java
@@ -1,4 +1,4 @@
-package org.skyscreamer.yoga.enricher;
+package org.skyscreamer.yoga.listener;
 
 import java.util.Map;
 
@@ -18,9 +18,9 @@ import org.skyscreamer.yoga.test.util.DummyHttpServletResponse;
 /**
  * User: corby Date: 5/14/12
  */
-public class HrefEnricherTest extends AbstractTraverserTest
+public class HrefListenerTest extends AbstractTraverserTest
 {
-    // Put an HrefEnricher in the enricher chain. Traverse a user object where
+    // Put an HrefListener in the listener chain. Traverse a user object where
     // the @URITemplate is defined
     // as "/user/{id}". Verify that the correct URL is appended to the output.
     @Test
@@ -30,7 +30,7 @@ public class HrefEnricherTest extends AbstractTraverserTest
         ResultTraverser traverser = new ResultTraverser();
 
         YogaRequestContext requestContext = new YogaRequestContext( "test",
-                new DummyHttpServletRequest(), new DummyHttpServletResponse(), new HrefEnricher() );
+                new DummyHttpServletRequest(), new DummyHttpServletResponse(), new HrefListener() );
         Map<String, Object> objectTree = doTraverse( solomon, ":", traverser, requestContext );
 
         Assert.assertEquals( "/user/" + solomon.getId() + ".test", objectTree.get( "href" ) );
@@ -38,7 +38,7 @@ public class HrefEnricherTest extends AbstractTraverserTest
 
     // No @URITemplate annotation exists on the Album class, but the
     // AlbumFieldPopulator defines a template.
-    // Put an HrefEnricher in the enricher chain, and verify that the correct
+    // Put an HrefListener in the listener chain, and verify that the correct
     // URL is appended to the output
     @Test
     public void testFieldPopulator()
@@ -48,7 +48,7 @@ public class HrefEnricherTest extends AbstractTraverserTest
         populatorRegistry.register( new AlbumFieldPopulator() );
 
         YogaRequestContext requestContext = new YogaRequestContext( "test",
-                new DummyHttpServletRequest(), new DummyHttpServletResponse(), new HrefEnricher( this.populatorRegistry ) );
+                new DummyHttpServletRequest(), new DummyHttpServletResponse(), new HrefListener( this.populatorRegistry ) );
         Map<String, Object> objectTree = doTraverse( funeral, ":", traverser, requestContext );
 
         Assert.assertEquals( "/album/" + funeral.getId() + ".test", objectTree.get( "href" ) );

--- a/yoga-core/src/test/java/org/skyscreamer/yoga/listener/MetadataLinkListenerTest.java
+++ b/yoga-core/src/test/java/org/skyscreamer/yoga/listener/MetadataLinkListenerTest.java
@@ -1,20 +1,13 @@
-package org.skyscreamer.yoga.enricher;
+package org.skyscreamer.yoga.listener;
 
 import junit.framework.Assert;
 import org.junit.Test;
-import org.skyscreamer.yoga.listener.RenderingEvent;
-import org.skyscreamer.yoga.listener.RenderingEventType;
 import org.skyscreamer.yoga.mapper.ResultTraverser;
 import org.skyscreamer.yoga.mapper.YogaRequestContext;
 import org.skyscreamer.yoga.metadata.MapMetaDataServiceImpl;
-import org.skyscreamer.yoga.model.ObjectMapHierarchicalModelImpl;
-import org.skyscreamer.yoga.populator.DefaultFieldPopulatorRegistry;
 import org.skyscreamer.yoga.selector.CoreSelector;
 import org.skyscreamer.yoga.test.model.basic.DataGenerator;
 import org.skyscreamer.yoga.test.model.extended.Album;
-import org.skyscreamer.yoga.test.model.extended.Artist;
-import org.skyscreamer.yoga.test.model.extended.Song;
-import org.skyscreamer.yoga.test.model.extended.User;
 import org.skyscreamer.yoga.test.util.AbstractTraverserTest;
 import org.skyscreamer.yoga.test.util.DummyHttpServletRequest;
 import org.skyscreamer.yoga.test.util.DummyHttpServletResponse;
@@ -26,10 +19,10 @@ import java.util.Map;
  * User: corby
  * Date: 6/7/12
  */
-public class MetadataLinkEnricherTest extends AbstractTraverserTest
+public class MetadataLinkListenerTest extends AbstractTraverserTest
 {
     @Test
-    // Add the MetadataLinkEnricher to the enricher chain. The output will render an href to view the metadata
+    // Add the MetadataLinkListener to the listener chain. The output will render an href to view the metadata
     // for the album object.
     public void testMetadataHref()
     {
@@ -45,12 +38,12 @@ public class MetadataLinkEnricherTest extends AbstractTraverserTest
         typeMappings.put( "album", Album.class );
         service.setTypeMappings( typeMappings );
 
-        MetadataLinkEnricher metadataLinkEnricher = new MetadataLinkEnricher();
-        metadataLinkEnricher.setMetaDataService( service );
+        MetadataLinkListener metadataLinkListener = new MetadataLinkListener();
+        metadataLinkListener.setMetaDataService( service );
 
         ResultTraverser traverser = new ResultTraverser();
         YogaRequestContext requestContext = new YogaRequestContext( fileExtension,
-                new DummyHttpServletRequest(), new DummyHttpServletResponse(), metadataLinkEnricher );
+                new DummyHttpServletRequest(), new DummyHttpServletResponse(), metadataLinkListener );
         Map<String, Object> objectTree = doTraverse( signOfTheTimes, ":", traverser, requestContext );
 
         Map<String,String> metadataMap = (Map<String,String>) objectTree.get( "metadata" );

--- a/yoga-core/src/test/java/org/skyscreamer/yoga/listener/NavigationLinksListenerTest.java
+++ b/yoga-core/src/test/java/org/skyscreamer/yoga/listener/NavigationLinksListenerTest.java
@@ -1,9 +1,7 @@
-package org.skyscreamer.yoga.enricher;
+package org.skyscreamer.yoga.listener;
 
 import junit.framework.Assert;
 import org.junit.Test;
-import org.skyscreamer.yoga.listener.RenderingEvent;
-import org.skyscreamer.yoga.listener.RenderingEventType;
 import org.skyscreamer.yoga.mapper.YogaRequestContext;
 import org.skyscreamer.yoga.model.ObjectMapHierarchicalModelImpl;
 import org.skyscreamer.yoga.populator.DefaultFieldPopulatorRegistry;
@@ -14,7 +12,7 @@ import org.skyscreamer.yoga.test.util.DummyHttpServletResponse;
 
 import java.util.Map;
 
-public class NavigationLinksEnricherTest
+public class NavigationLinksListenerTest
 {
     static YogaRequestContext requestContext = new YogaRequestContext( "map",
             new DummyHttpServletRequest(), new DummyHttpServletResponse() );
@@ -27,7 +25,7 @@ public class NavigationLinksEnricherTest
         RenderingEvent event = new RenderingEvent( RenderingEventType.POJO_CHILD, model, leaf,
                 leaf.getClass(), requestContext, new CoreSelector(
                         new DefaultFieldPopulatorRegistry() ) );
-        new NavigationLinksEnricher().eventOccurred( event );
+        new NavigationLinksListener().eventOccurred( event );
 
         Map<String, Object> objectTree = model.getUnderlyingModel();
 

--- a/yoga-demos/yoga-demo-shared/src/main/resources/applicationContext.xml
+++ b/yoga-demos/yoga-demo-shared/src/main/resources/applicationContext.xml
@@ -67,10 +67,12 @@
     <!-- DATABSE CONFIG END -->
 
 
-    <!-- YOGA CONFIG BEGING -->
+    <!-- YOGA CONFIG BEGIN -->
 
     <bean id="resultTraverser" class="org.skyscreamer.yoga.mapper.ResultTraverser" 
         p:classFinderStrategy-ref="hibernateClassFinder" />
+
+    <bean id="hibernateClassFinder" class="org.skyscreamer.yoga.demo.mapper.HibernateClassFinderStrategy" />
 
     <bean id="selectorParser" class="org.skyscreamer.yoga.selector.parser.LinkedInSelectorParser">
         <constructor-arg ref="fieldPopulatorRegistry"/>
@@ -81,8 +83,6 @@
     <bean id="aliasSelectorResolver" class="org.skyscreamer.yoga.selector.parser.DynamicPropertyResolver"
         p:propertyFile="classpath:selectorAlias.properties" />
 
-    <bean id="hibernateClassFinder" class="org.skyscreamer.yoga.demo.mapper.HibernateClassFinderStrategy" />
-
     <bean id="fieldPopulatorRegistry" class="org.skyscreamer.yoga.populator.DefaultFieldPopulatorRegistry">
         <constructor-arg>
             <list>
@@ -91,7 +91,7 @@
         </constructor-arg>
     </bean>
 
-    <bean id="hrefEnricher" class="org.skyscreamer.yoga.enricher.HrefEnricher"
+    <bean id="hrefListener" class="org.skyscreamer.yoga.listener.HrefListener"
         p:fieldPopulatorRegistry-ref="fieldPopulatorRegistry" />
 
     <bean id="renderingListenerRegistry" class="org.skyscreamer.yoga.listener.RenderingListenerRegistry">
@@ -100,13 +100,13 @@
                 <bean class="org.skyscreamer.yoga.limits.CountLimitRenderingListener">
                     <constructor-arg value="2000" />
                 </bean>
-                <ref bean="hrefEnricher" />
-                <bean class="org.skyscreamer.yoga.enricher.SelectorBuilderEnricher" />
-                <bean class="org.skyscreamer.yoga.enricher.NavigationLinksEnricher"
-                    p:hrefEnricher-ref="hrefEnricher" />
-                <bean class="org.skyscreamer.yoga.enricher.ModelDefinitionBuilder"
+                <ref bean="hrefListener" />
+                <bean class="org.skyscreamer.yoga.listener.SelectorBuilderListener" />
+                <bean class="org.skyscreamer.yoga.listener.NavigationLinksListener"
+                    p:hrefListener-ref="hrefListener" />
+                <bean class="org.skyscreamer.yoga.listener.ModelDefinitionListener"
                     p:fieldPopulatorRegistry-ref="fieldPopulatorRegistry"/>
-                <bean class="org.skyscreamer.yoga.enricher.MetadataLinkEnricher"
+                <bean class="org.skyscreamer.yoga.listener.MetadataLinkListener"
                     p:metaDataService-ref="metaDataService" />
             </list>
         </constructor-arg>


### PR DESCRIPTION
All implementations of the RenderingListener interface use the Listener
suffix for clarity and consistency
