### PR TITLE
Adding additional YogaBuilder extension points for CoreSelector, SelectorResolver and MetaDataRegistry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>3.1</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/builder/YogaBuilder.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/builder/YogaBuilder.java
@@ -13,6 +13,7 @@ import org.skyscreamer.yoga.listener.RenderingListenerRegistry;
 import org.skyscreamer.yoga.listener.SelectorBuilderListener;
 import org.skyscreamer.yoga.listener.UriGenerator;
 import org.skyscreamer.yoga.metadata.DefaultMetaDataRegistry;
+import org.skyscreamer.yoga.metadata.MetaDataRegistry;
 import org.skyscreamer.yoga.selector.SelectorResolver;
 import org.skyscreamer.yoga.selector.parser.DynamicPropertyResolver;
 import org.skyscreamer.yoga.util.ClassFinderStrategy;
@@ -27,28 +28,41 @@ public class YogaBuilder
 
     protected RenderingListenerRegistry _registry = new RenderingListenerRegistry();
 
-    protected SelectorResolver _selectorResolver = new SelectorResolver();
+    protected  SelectorResolver _selectorResolver;
 
     protected InputStream _aliasProperties = null;
 
     protected boolean _createAllLinks = false;
 
-    private DefaultMetaDataRegistry _metaDataRegistry = new DefaultMetaDataRegistry();
+    private MetaDataRegistry _metaDataRegistry;
 
+    public YogaBuilder()
     {
+    	init();
+    }
+
+	/**
+	 * there are cases where a user might want to override meta data registry,
+	 * selector resolver and/or CoreSelector implementations. This would be the
+	 * place to do it, since we have complex dependencies for those objects, and
+	 * we need those objects set up before other setters are called.
+	 */
+	protected void init() {
+		_metaDataRegistry = new DefaultMetaDataRegistry();
+    	_selectorResolver = new SelectorResolver();
         _selectorResolver.getBaseSelector().setEntityConfigurationRegistry( new DefaultEntityConfigurationRegistry() );
         _metaDataRegistry.setCoreSelector( this._selectorResolver.getBaseSelector() );
         _metaDataRegistry.setRootMetaDataUrl( "/metadata/" );
-    }
+	}
 
     // -------------- helpers ---------
-    
+
     protected void checkFinalized()
     {
         if(_finalized)
             throw new IllegalStateException( "You cannot update builder information after it's been used to generate artifacts" );
     }
-    
+
     // -------------- getters ---------
 
     public ClassFinderStrategy getClassFinderStrategy()
@@ -80,8 +94,8 @@ public class YogaBuilder
     {
         return !_metaDataRegistry.getTypes().isEmpty();
     }
-    
-    public DefaultMetaDataRegistry getMetaDataRegistry()
+
+    public MetaDataRegistry getMetaDataRegistry()
     {
         return _metaDataRegistry;
     }
@@ -155,7 +169,7 @@ public class YogaBuilder
         setAliasProperties( propertyFile );
         return this;
     }
-    
+
     public YogaBuilder withOutputCountLimit( int countLimit )
     {
         setOutputCountLimit( countLimit );
@@ -179,9 +193,9 @@ public class YogaBuilder
         setYogaMetaDataRegisteredClasses( classes );
         return this;
     }
-    
+
     // finalize!
-    
+
     public void finalize()
     {
         if( _finalized )

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/configuration/DefaultEntityConfigurationRegistry.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/configuration/DefaultEntityConfigurationRegistry.java
@@ -25,7 +25,7 @@ public class DefaultEntityConfigurationRegistry implements EntityConfigurationRe
      * Constructs a registry and initializes it with an array of initial configurations.
      * @param entityConfigurations Initial configurations to register
      */
-    public DefaultEntityConfigurationRegistry(YogaEntityConfiguration<?>... entityConfigurations)
+    public DefaultEntityConfigurationRegistry( YogaEntityConfiguration<?>... entityConfigurations )
     {
         register( entityConfigurations );
     }
@@ -34,7 +34,7 @@ public class DefaultEntityConfigurationRegistry implements EntityConfigurationRe
      * Constructs a registry and initializes it with an list of initial configurations.
      * @param entityConfigurations Initial configurations to register
      */
-    public DefaultEntityConfigurationRegistry(List<YogaEntityConfiguration<?>> entityConfigurations)
+    public DefaultEntityConfigurationRegistry( List<YogaEntityConfiguration<?>> entityConfigurations )
     {
         register( entityConfigurations.toArray(new YogaEntityConfiguration[0]) );
     }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/metadata/MetaDataRegistry.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/metadata/MetaDataRegistry.java
@@ -2,11 +2,19 @@ package org.skyscreamer.yoga.metadata;
 
 import java.util.Collection;
 
+import org.skyscreamer.yoga.selector.CoreSelector;
+
 public interface MetaDataRegistry
 {
     Collection<String> getTypes();
 
     TypeMetaData getMetaData( String type, String suffix );
 
-    String getMetadataHref(Class<?> type, String suffix);
+    String getMetadataHref( Class<?> type, String suffix );
+
+    void setCoreSelector( CoreSelector coreSelector );
+
+	void registerClasses( Class<?> ... classes );
+
+	void setRootMetaDataUrl( String rootMetaDataUrl );
 }

--- a/yoga-demos/yoga-demo-jaxrs-shared/pom.xml
+++ b/yoga-demos/yoga-demo-jaxrs-shared/pom.xml
@@ -16,7 +16,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <version>2.3.1</version>
+               <version>3.1</version>
                <configuration>
                    <source>1.6</source>
                    <target>1.6</target>

--- a/yoga-demos/yoga-demo-jersey-guice/pom.xml
+++ b/yoga-demos/yoga-demo-jersey-guice/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <version>2.3.1</version>
+               <version>3.1</version>
                <configuration>
                    <source>1.6</source>
                    <target>1.6</target>

--- a/yoga-demos/yoga-demo-jersey-spring/pom.xml
+++ b/yoga-demos/yoga-demo-jersey-spring/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <version>2.3.1</version>
+               <version>3.1</version>
                <configuration>
                    <source>1.6</source>
                    <target>1.6</target>

--- a/yoga-demos/yoga-demo-jersey-standalone/pom.xml
+++ b/yoga-demos/yoga-demo-jersey-standalone/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <version>2.3.1</version>
+               <version>3.1</version>
                <configuration>
                    <source>1.6</source>
                    <target>1.6</target>

--- a/yoga-demos/yoga-demo-resteasy/pom.xml
+++ b/yoga-demos/yoga-demo-resteasy/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <version>2.3.1</version>
+               <version>3.1</version>
                <configuration>
                    <source>1.6</source>
                    <target>1.6</target>

--- a/yoga-demos/yoga-demo-springmvc/pom.xml
+++ b/yoga-demos/yoga-demo-springmvc/pom.xml
@@ -31,7 +31,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <version>2.3.1</version>
+               <version>3.1</version>
                <configuration>
                    <source>1.6</source>
                    <target>1.6</target>


### PR DESCRIPTION
adding some additional configuration options for YogaBuilder based on user requests.  You can now override CoreSelector, SelectorResolver and MetaDataRegistry.

updated the maven compiler plugin to 3.1 (from 2.3.1).  Supposedly, it's faster.
