### PR TITLE
Fixed null handling in iterables

### DIFF
--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ResultTraverser.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/ResultTraverser.java
@@ -50,7 +50,7 @@ public class ResultTraverser
         {
             for (Object o : iterable)
             {
-                if (isPrimitive( o.getClass() ))
+                if (o == null || isPrimitive( o.getClass() ))
                 {
                     model.addValue( o );
                 }

--- a/yoga-core/src/test/java/org/skyscreamer/yoga/mapper/ResultTraverserTest.java
+++ b/yoga-core/src/test/java/org/skyscreamer/yoga/mapper/ResultTraverserTest.java
@@ -80,6 +80,22 @@ public class ResultTraverserTest
     }
 
     @Test
+    public void testNullValuesInList() throws IOException {
+        BasicTestDataLeaf input = new BasicTestDataLeaf();
+        List<String> list = Arrays.asList( "someValue", null, "aThirdValue" );
+        input.setRandomStrings( list );
+        ObjectMapHierarchicalModelImpl model = new ObjectMapHierarchicalModelImpl();
+
+        FieldSelector selector = new FieldSelector();
+        selector.register( "randomStrings", new FieldSelector() );
+
+        resultTraverser.traverse( input, new CompositeSelector( resolver.getBaseSelector(), selector ), model, requestContext );
+
+        Map<String, Object> objectTree = model.getUnderlyingModel();
+        Assert.assertEquals( list, objectTree.get( "randomStrings" ) );
+    }
+
+    @Test
     public void testBasicCombinedSelctor() throws IOException
     {
         BasicTestDataLeaf input = new BasicTestDataLeaf();


### PR DESCRIPTION
Fixes a NullPointerException in the ResultTraverser when serializing iterables that contain null values (see the added test case). This fix adds an extra null check before trying to determine the Class of an object inside the iterable.
