### PR TITLE
Support for Jackson 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .project
 .settings
 .springBeans
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-<!-- change --> 
+<!-- change -->
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
@@ -98,8 +98,9 @@
     <properties>
         <spring.version>3.0.3.RELEASE</spring.version>
         <jackson.version>1.9.12</jackson.version>
+        <jackson2.version>2.3.0</jackson2.version>
     </properties>
- 
+
     <modules>
         <module>yoga-core</module>
         <module>yoga-integration</module>

--- a/yoga-core/pom.xml
+++ b/yoga-core/pom.xml
@@ -54,6 +54,13 @@
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
             <version>${jackson.version}</version>
+           <optional>true</optional>
         </dependency>
+       <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>${jackson2.version}</version>
+          <optional>true</optional>
+       </dependency>
     </dependencies>
 </project>

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/model/ArrayStreamingJsonHierarchicalModel.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/model/ArrayStreamingJsonHierarchicalModel.java
@@ -1,16 +1,17 @@
 package org.skyscreamer.yoga.model;
 
+import org.skyscreamer.yoga.view.json.generator.GeneratorAdapter;
+import org.skyscreamer.yoga.view.json.generator.JacksonJsonGeneratorAdapter;
+
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerator;
-
-public class ArrayStreamingJsonHierarchicalModel implements ListHierarchicalModel<JsonGenerator>
+public class ArrayStreamingJsonHierarchicalModel implements ListHierarchicalModel<GeneratorAdapter>
 {
 
-    private JsonGenerator generator;
+    private GeneratorAdapter generator;
     private ObjectStreamingJsonHierarchicalModel objectModel;
-    
-    public ArrayStreamingJsonHierarchicalModel(JsonGenerator generator) throws IOException
+
+    public ArrayStreamingJsonHierarchicalModel(GeneratorAdapter generator) throws IOException
     {
         this.generator = generator;
         objectModel = new ObjectStreamingJsonHierarchicalModel(generator, this);
@@ -18,7 +19,7 @@ public class ArrayStreamingJsonHierarchicalModel implements ListHierarchicalMode
     }
 
     public ArrayStreamingJsonHierarchicalModel(
-            JsonGenerator generator,
+            GeneratorAdapter generator,
             ObjectStreamingJsonHierarchicalModel objectModel) throws IOException
     {
         this.generator = generator;
@@ -49,7 +50,7 @@ public class ArrayStreamingJsonHierarchicalModel implements ListHierarchicalMode
     }
 
     @Override
-    public JsonGenerator getUnderlyingModel()
+    public GeneratorAdapter getUnderlyingModel()
     {
         return generator;
     }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/model/ObjectStreamingJsonHierarchicalModel.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/model/ObjectStreamingJsonHierarchicalModel.java
@@ -1,18 +1,18 @@
 package org.skyscreamer.yoga.model;
 
+import org.skyscreamer.yoga.view.json.generator.GeneratorAdapter;
+
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerator;
-
 public class ObjectStreamingJsonHierarchicalModel implements
-        MapHierarchicalModel<JsonGenerator>
+        MapHierarchicalModel<GeneratorAdapter>
 {
-    
 
-    protected JsonGenerator generator;
+
+    protected GeneratorAdapter generator;
 	private ArrayStreamingJsonHierarchicalModel arrayModel;
 
-    public ObjectStreamingJsonHierarchicalModel(JsonGenerator generator)
+    public ObjectStreamingJsonHierarchicalModel(GeneratorAdapter generator)
             throws IOException
     {
         this.generator = generator;
@@ -21,20 +21,20 @@ public class ObjectStreamingJsonHierarchicalModel implements
     }
 
     public ObjectStreamingJsonHierarchicalModel(
-            JsonGenerator generator,
+            GeneratorAdapter generator,
             ArrayStreamingJsonHierarchicalModel arrayModel) throws IOException
     {
         this.generator = generator;
         this.arrayModel = arrayModel;
     }
-    
+
     public void start() throws IOException
     {
         generator.writeStartObject();
     }
 
 	@Override
-    public JsonGenerator getUnderlyingModel()
+    public GeneratorAdapter getUnderlyingModel()
     {
         return generator;
     }
@@ -51,14 +51,14 @@ public class ObjectStreamingJsonHierarchicalModel implements
         generator.writeObjectField(name, result);
     }
 
-    public MapHierarchicalModel<JsonGenerator> createChildMap(String name) throws IOException
+    public MapHierarchicalModel<GeneratorAdapter> createChildMap(String name) throws IOException
     {
         generator.writeFieldName(name);
         this.start();
         return this;
     }
 
-    public ListHierarchicalModel<JsonGenerator> createChildList(String name) throws IOException
+    public ListHierarchicalModel<GeneratorAdapter> createChildList(String name) throws IOException
     {
         generator.writeFieldName(name);
         arrayModel.start();

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/util/ClassUtil.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/util/ClassUtil.java
@@ -1,0 +1,31 @@
+package org.skyscreamer.yoga.util;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: nk
+ * Date: 12/17/13
+ * Time: 6:33 AM
+ */
+public class ClassUtil {
+
+    public static final boolean jackson2Present =
+            classIsPresent("com.fasterxml.jackson.databind.ObjectMapper", ClassUtil.class.getClassLoader()) &&
+                    classIsPresent("com.fasterxml.jackson.core.JsonGenerator", ClassUtil.class.getClassLoader());
+
+    public static final boolean jacksonPresent =
+                            classIsPresent("org.codehaus.jackson.map.ObjectMapper", ClassUtil.class.getClassLoader()) &&
+                                    classIsPresent("org.codehaus.jackson.JsonGenerator", ClassUtil.class.getClassLoader());
+
+    public static boolean classIsPresent(String className, ClassLoader classLoader) {
+        try {
+            if (classLoader == null) {
+                Class.forName(className);
+            } else {
+                classLoader.loadClass(className);
+            }
+            return true;
+        } catch (Throwable ex) {
+            return false;
+        }
+    }
+}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/view/StreamingJsonSelectorView.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/view/StreamingJsonSelectorView.java
@@ -1,64 +1,55 @@
 package org.skyscreamer.yoga.view;
 
-import java.io.IOException;
-import java.io.OutputStream;
-
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonGenerator;
 import org.skyscreamer.yoga.mapper.YogaRequestContext;
 import org.skyscreamer.yoga.model.ArrayStreamingJsonHierarchicalModel;
 import org.skyscreamer.yoga.model.HierarchicalModel;
 import org.skyscreamer.yoga.model.ObjectStreamingJsonHierarchicalModel;
+import org.skyscreamer.yoga.util.ClassUtil;
+import org.skyscreamer.yoga.view.json.generator.GeneratorAdapter;
+import org.skyscreamer.yoga.view.json.generator.Jackson2JsonGeneratorAdapter;
+import org.skyscreamer.yoga.view.json.generator.JacksonJsonGeneratorAdapter;
 
-public class StreamingJsonSelectorView extends AbstractYogaView
-{
-    JsonFactory jsonFactory = new JsonFactory();
+import java.io.IOException;
+import java.io.OutputStream;
 
-    public void setJsonFactory(JsonFactory jsonFactory)
-    {
-	    this.jsonFactory = jsonFactory;
-    }
+public class StreamingJsonSelectorView extends AbstractYogaView {
 
     @Override
     protected void render(Object value, YogaRequestContext context,
-            OutputStream os) throws Exception
-    {
-        JsonGenerator generator = createGenerator( os );
-        HierarchicalModel<JsonGenerator> model = createModel( value, generator );
-        _resultTraverser.traverse( value, context.getSelector(), model, context );
+                          OutputStream os) throws Exception {
+        GeneratorAdapter generator = getGeneratorAdapter(os);
+        HierarchicalModel<GeneratorAdapter> model = createModel(value, generator);
+        _resultTraverser.traverse(value, context.getSelector(), model, context);
         model.getUnderlyingModel().close();
     }
 
-    protected JsonGenerator createGenerator(OutputStream outputStream)
-            throws IOException
-    {
-		return jsonFactory.createJsonGenerator(outputStream);
+    private GeneratorAdapter getGeneratorAdapter(OutputStream out) throws IOException {
+        if(ClassUtil.jacksonPresent) {
+            return new JacksonJsonGeneratorAdapter(out);
+        }  else if(ClassUtil.jackson2Present) {
+            return new Jackson2JsonGeneratorAdapter(out);
+        }  else {
+            throw new IllegalStateException("Jackson library not in classpath.");
+        }
     }
 
-    protected HierarchicalModel<JsonGenerator> createModel(Object value,
-            JsonGenerator generator) throws IOException,
-            JsonGenerationException
-    {
-        if (value instanceof Iterable)
-        {
+    protected HierarchicalModel<GeneratorAdapter> createModel(Object value,
+                                                           GeneratorAdapter generator) throws IOException
+             {
+        if (value instanceof Iterable) {
             return new ArrayStreamingJsonHierarchicalModel(generator);
-        } 
-        else
-        {
+        } else {
             return new ObjectStreamingJsonHierarchicalModel(generator);
         }
     }
 
     @Override
-    public String getContentType()
-    {
+    public String getContentType() {
         return "application/json";
     }
 
     @Override
-    public String getHrefSuffix()
-    {
+    public String getHrefSuffix() {
         return "json";
     }
 

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/generator/GeneratorAdapter.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/generator/GeneratorAdapter.java
@@ -1,0 +1,28 @@
+package org.skyscreamer.yoga.view.json.generator;
+
+import java.io.IOException;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: nk
+ * Date: 12/17/13
+ * Time: 7:15 AM
+ */
+public interface GeneratorAdapter {
+
+    void writeStartArray() throws IOException;
+
+    void writeEndArray() throws IOException;
+
+    void writeObject(Object instance) throws IOException;
+
+    void writeStartObject() throws IOException;
+
+    void writeEndObject() throws IOException;
+
+    void writeObjectField(String name, Object result) throws IOException;
+
+    void writeFieldName(String name) throws IOException;
+
+    void close() throws IOException;
+}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/generator/Jackson2JsonGeneratorAdapter.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/generator/Jackson2JsonGeneratorAdapter.java
@@ -1,0 +1,68 @@
+package org.skyscreamer.yoga.view.json.generator;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: nk
+ * Date: 12/17/13
+ * Time: 7:27 AM
+ */
+public class Jackson2JsonGeneratorAdapter implements GeneratorAdapter {
+
+    private static final JsonFactory jsonFactory = new JsonFactory();
+
+    private JsonGenerator generator;
+
+    public Jackson2JsonGeneratorAdapter(OutputStream out) throws IOException {
+        this.generator = this.createGenerator(out);
+    }
+
+    protected JsonGenerator createGenerator(OutputStream outputStream)
+            throws IOException {
+        return jsonFactory.createGenerator(outputStream);
+    }
+
+    @Override
+    public void writeFieldName(String name) throws IOException {
+        generator.writeFieldName(name);
+    }
+
+    @Override public void close() throws IOException {
+        generator.close();
+    }
+
+    @Override
+    public void writeObjectField(String name, Object result) throws IOException {
+        generator.writeObjectField(name, result);
+    }
+
+    @Override
+    public void writeEndObject() throws IOException {
+        generator.writeEndObject();
+    }
+
+    @Override
+    public void writeStartObject() throws IOException {
+        generator.writeStartObject();
+    }
+
+    @Override
+    public void writeStartArray() throws IOException {
+        generator.writeStartArray();
+    }
+
+    @Override
+    public void writeEndArray() throws IOException {
+        generator.writeEndArray();
+    }
+
+    @Override
+    public void writeObject(Object instance) throws IOException {
+        generator.writeObject(instance);
+    }
+}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/generator/JacksonJsonGeneratorAdapter.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/generator/JacksonJsonGeneratorAdapter.java
@@ -1,0 +1,69 @@
+package org.skyscreamer.yoga.view.json.generator;
+
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: nk
+ * Date: 12/17/13
+ * Time: 6:58 AM
+ */
+public class JacksonJsonGeneratorAdapter implements GeneratorAdapter {
+
+
+    private static final JsonFactory jsonFactory = new JsonFactory();
+
+    private JsonGenerator generator;
+
+    public JacksonJsonGeneratorAdapter(OutputStream os) throws IOException {
+        this.generator = this.createGenerator(os);
+    }
+
+    protected JsonGenerator createGenerator(OutputStream outputStream)
+            throws IOException {
+        return jsonFactory.createJsonGenerator(outputStream);
+    }
+
+    @Override
+    public void writeFieldName(String name) throws IOException {
+        generator.writeFieldName(name);
+    }
+
+    @Override public void close() throws IOException {
+        generator.close();
+    }
+
+    @Override
+    public void writeObjectField(String name, Object result) throws IOException {
+        generator.writeObjectField(name, result);
+    }
+
+    @Override
+    public void writeEndObject() throws IOException {
+        generator.writeEndObject();
+    }
+
+    @Override
+    public void writeStartObject() throws IOException {
+        generator.writeStartObject();
+    }
+
+    @Override
+    public void writeStartArray() throws IOException {
+        generator.writeStartArray();
+    }
+
+    @Override
+    public void writeEndArray() throws IOException {
+        generator.writeEndArray();
+    }
+
+    @Override
+    public void writeObject(Object instance) throws IOException {
+        generator.writeObject(instance);
+    }
+}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/serializer/Jackson2Serializer.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/serializer/Jackson2Serializer.java
@@ -1,0 +1,25 @@
+package org.skyscreamer.yoga.view.json.serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: nk
+ * Date: 12/17/13
+ * Time: 6:16 AM
+ */
+public class Jackson2Serializer implements JsonSerialiazer {
+
+    private ObjectMapper objectMapper;
+
+    public Jackson2Serializer() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override public void serialize(OutputStream out, Object obj) throws IOException {
+        objectMapper.writeValue(out, obj);
+    }
+}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/serializer/JacksonSerializer.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/serializer/JacksonSerializer.java
@@ -1,0 +1,26 @@
+package org.skyscreamer.yoga.view.json.serializer;
+
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: nk
+ * Date: 12/17/13
+ * Time: 6:16 AM
+ */
+public class JacksonSerializer implements JsonSerialiazer {
+
+    private ObjectMapper objectMapper;
+
+    public JacksonSerializer() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override public void serialize(OutputStream out, Object obj) throws IOException {
+        objectMapper.writeValue(out, obj);
+    }
+
+}

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/serializer/JsonSerialiazer.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/serializer/JsonSerialiazer.java
@@ -1,0 +1,15 @@
+package org.skyscreamer.yoga.view.json.serializer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: nk
+ * Date: 12/17/13
+ * Time: 6:17 AM
+ */
+public interface JsonSerialiazer {
+
+    public void serialize(OutputStream out, Object obj) throws IOException;
+}

--- a/yoga-demos/yoga-demo-shared/pom.xml
+++ b/yoga-demos/yoga-demo-shared/pom.xml
@@ -110,6 +110,22 @@
             <version>1</version>
         </dependency>
 
+       <!--
+            Jackson is no longer a transient dependency.
+            You must explicitly declare it in your pom.xml file.
+            Either Jackson or Jackson 2 is fine.
+       -->
+       <!--<dependency>-->
+          <!--<groupId>com.fasterxml.jackson.core</groupId>-->
+          <!--<artifactId>jackson-databind</artifactId>-->
+          <!--<version>${jackson2.version}</version>-->
+       <!--</dependency>-->
+       <dependency>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+          <version>${jackson.version}</version>
+       </dependency>
+
         <dependency>
             <groupId>org.tuckey</groupId>
             <artifactId>urlrewritefilter</artifactId>


### PR DESCRIPTION
Hello, I was scratching an itch and I thought you might want to use this code.

I have a project that uses Jackson 2.x for json serialization and I wanted to use yoga without having to import Jackson 1.x dependencies. This PR makes Jackson an optional dependency and the user can choose which version to use by including the dependency in his/her project. As long as either Jackson 1.x or 2.x is in the classpath yoga works as expected.
