### PR TITLE
Consider Date primitive

### DIFF
--- a/yoga-core/src/main/java/org/skyscreamer/yoga/util/ObjectUtil.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/util/ObjectUtil.java
@@ -1,11 +1,13 @@
 package org.skyscreamer.yoga.util;
 
+import java.util.Date;
+
 public class ObjectUtil
 {
     public static boolean isPrimitive( Class<?> clazz )
     {
         return clazz.isPrimitive() || clazz.isEnum() || Number.class.isAssignableFrom( clazz )
                 || String.class.isAssignableFrom( clazz ) || Boolean.class.isAssignableFrom( clazz )
-                || Character.class.isAssignableFrom( clazz );
+                || Character.class.isAssignableFrom( clazz ) || Date.class.isAssignableFrom( clazz );
     }
 }


### PR DESCRIPTION
I was having issues with Yoga breaking date handling in comparison to how plain Jersey did it. Jersey would serialize an epoch  int where as Yoga would just give me { }. I tracked it down into the PojoProperty and it was calling ObjectUtil.isPrimitive(). By adding Date to the list of primitives this solves this issue. 

I can't imagine any time you would ever want to get the date object or use a selector on it (seeing as how it only has one non-deprecated method). I checked and do not see any reason this should cause issues and all tests passed.

Let me know what you think. I've been able to work around this via extending PojoProperty but I feel like this is more the desired behavior.
