### PR TITLE
Handle maps in the result traverser

### DIFF
--- a/yoga-core/src/main/java/org/skyscreamer/yoga/listener/RenderingEventType.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/listener/RenderingEventType.java
@@ -3,5 +3,6 @@ package org.skyscreamer.yoga.listener;
 public enum RenderingEventType
 {
     LIST_CHILD,
-    POJO_CHILD
+    POJO_CHILD,
+    MAP_CHILD
 }

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/YogaRequestContext.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/mapper/YogaRequestContext.java
@@ -101,6 +101,14 @@ public class YogaRequestContext
                 iterable, iterable.getClass(), context, selector));
     }
     
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void emitEvent(MapHierarchicalModel<?> model, Map<?,?> value,
+        YogaRequestContext context, Selector selector) throws IOException
+    {
+        emitEvent(new RenderingEvent(RenderingEventType.MAP_CHILD, model,
+                value, Map.class, context, selector));
+    }
+    
     public Selector getSelector()
     {
         return this.selectorResolver.getSelector( request );


### PR DESCRIPTION
The result traverser treats maps as pojos and therefore does not expose the keys in the map to selectors. With this change, maps are treated specifically and selectors can be applied to their fields. 
This is working in our application. Any feedback welcomed.
