### PR TITLE
Removed jackson-mapper-asl and replaced with jackson-databind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .project
 .settings
 .springBeans
+yoga*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-<!-- change --> 
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
@@ -9,7 +8,7 @@
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>yoga</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <url>https://github.com/skyscreamer/yoga</url>
@@ -55,50 +54,11 @@
                     <target>1.6</target>
                 </configuration>
             </plugin>
-	    <!-- TODO: This causes problems with releases.  Commenting out.
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8.1</version>
-                <executions>
-                    <execution>
-                        <id>aggregate</id>
-                        <goals>
-                            <goal>aggregate</goal>
-                        </goals>
-                        <phase>site</phase>
-                    </execution>
-                </executions>
-		<configuration>
-		    <excludePackageNames>org.skyscreamer.yoga.demo</excludePackageNames>
-		</configuration>
-            </plugin>
-	    -->
         </plugins>
-	<!-- TODO: This causes problems with releases.  Commenting out.
-        <extensions>
-            <extension>
-                <groupId>org.apache.maven.scm</groupId>
-                <artifactId>maven-scm-provider-gitexe</artifactId>
-                <version>1.3</version>
-            </extension>
-            <extension>
-                <groupId>org.apache.maven.scm</groupId>
-                <artifactId>maven-scm-manager-plexus</artifactId>
-                <version>1.3</version>
-            </extension>
-            <extension>
-                <groupId>org.kathrynhuxtable.maven.wagon</groupId>
-                <artifactId>wagon-gitsite</artifactId>
-                <version>0.3.1</version>
-            </extension>
-        </extensions>
-	-->
     </build>
     <properties>
         <spring.version>3.0.3.RELEASE</spring.version>
-        <jackson.version>1.9.12</jackson.version>
-        <jackson2.version>2.4.1.3</jackson2.version>
+        <jackson2.version>2.12.4</jackson2.version>
     </properties>
  
     <modules>
@@ -106,15 +66,6 @@
         <module>yoga-integration</module>
         <module>yoga-demos</module>
     </modules>
-
-    <!-- TODO: This causes problems with releases.  Commenting out.
-    <distributionManagement>
-        <site>
-            <id>github-project-site</id>
-            <url>gitsite:git@github.com/skyscreamer/yoga.git</url>
-        </site>
-    </distributionManagement>
-    -->
 
     <profiles>
         <profile>

--- a/yoga-core/pom.xml
+++ b/yoga-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>yoga-core</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>Yoga Core</name>
@@ -44,11 +44,6 @@
             <artifactId>servlet-api</artifactId>
             <version>2.5</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/JacksonJsonGeneratorAdapter.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/JacksonJsonGeneratorAdapter.java
@@ -1,7 +1,7 @@
 package org.skyscreamer.yoga.view.json;
 
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -23,7 +23,7 @@ public class JacksonJsonGeneratorAdapter implements GeneratorAdapter {
 
 	protected JsonGenerator createGenerator(OutputStream outputStream)
 			throws IOException {
-		return jsonFactory.createJsonGenerator(outputStream);
+		return jsonFactory.createGenerator(outputStream);
 	}
 
 	@Override

--- a/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/JacksonSerializer.java
+++ b/yoga-core/src/main/java/org/skyscreamer/yoga/view/json/JacksonSerializer.java
@@ -1,6 +1,6 @@
 package org.skyscreamer.yoga.view.json;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/yoga-demos/pom.xml
+++ b/yoga-demos/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>yoga-demos</artifactId>

--- a/yoga-demos/yoga-demo-jaxrs-shared/pom.xml
+++ b/yoga-demos/yoga-demo-jaxrs-shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga-demos</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>yoga-demo-jaxrs-shared</artifactId>

--- a/yoga-demos/yoga-demo-jersey-guice/pom.xml
+++ b/yoga-demos/yoga-demo-jersey-guice/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga-demos</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>yoga-demo-jersey-guice</artifactId>

--- a/yoga-demos/yoga-demo-jersey-spring/pom.xml
+++ b/yoga-demos/yoga-demo-jersey-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga-demos</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>yoga-demo-jersey-spring</artifactId>

--- a/yoga-demos/yoga-demo-jersey-standalone/pom.xml
+++ b/yoga-demos/yoga-demo-jersey-standalone/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga-demos</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>yoga-demo-jersey-standalone</artifactId>

--- a/yoga-demos/yoga-demo-resteasy/pom.xml
+++ b/yoga-demos/yoga-demo-resteasy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga-demos</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>yoga-demo-resteasy</artifactId>

--- a/yoga-demos/yoga-demo-shared/pom.xml
+++ b/yoga-demos/yoga-demo-shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga-demos</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>yoga-demo-shared</artifactId>

--- a/yoga-demos/yoga-demo-springmvc/pom.xml
+++ b/yoga-demos/yoga-demo-springmvc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga-demos</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>yoga-demo-springmvc</artifactId>

--- a/yoga-integration/pom.xml
+++ b/yoga-integration/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>yoga-integration</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <url>https://github.com/skyscreamer/yoga</url>

--- a/yoga-integration/yoga-hibernate/pom.xml
+++ b/yoga-integration/yoga-hibernate/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>yoga-integration</artifactId>
         <groupId>org.skyscreamer</groupId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>yoga-hibernate</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>Yoga Hibernate</name>

--- a/yoga-integration/yoga-jaxrs/pom.xml
+++ b/yoga-integration/yoga-jaxrs/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga-integration</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>yoga-jaxrs</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.1.0</version>
 
     <packaging>jar</packaging>
 

--- a/yoga-integration/yoga-jersey/pom.xml
+++ b/yoga-integration/yoga-jersey/pom.xml
@@ -5,16 +5,16 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga-integration</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>yoga-jersey</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.1.0</version>
 
     <packaging>jar</packaging>
 
-    <name>Yoga JAX-RS</name>
+    <name>Yoga Jersey</name>
     <description>Extension to Yoga for simplified JAX-RS integration</description>
     <url>http://github.com/skyscreamer/yoga</url>
 

--- a/yoga-integration/yoga-springmvc/pom.xml
+++ b/yoga-integration/yoga-springmvc/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.skyscreamer</groupId>
         <artifactId>yoga-integration</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>org.skyscreamer</groupId>
     <artifactId>yoga-springmvc</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>Yoga Spring MVC</name>


### PR DESCRIPTION
 - version used had a verified vericode vulnerability
 - jackson databind was recommended as the replacement
 - https://community.veracode.com/s/question/0D52T00004rDeRkSAK/sca-found-vulnerabilities-on-the-following-component-jacksonmapperasl192jarlooking-at-the-cves-they-are-related-to-jacksondatabind-component-instead-jacksonmapper-why-is-that